### PR TITLE
Dev/improvements

### DIFF
--- a/components/esp32_ble_presense/__init__.py
+++ b/components/esp32_ble_presense/__init__.py
@@ -3,10 +3,12 @@
 
 import esphome.config_validation as cv
 import esphome.codegen as cg
+from esphome.components import time
 
 from esphome.const import (
     CONF_ID,
     CONF_AREA,
+    CONF_TIME_ID,
 )
 
 CODEOWNERS = ["@formatBCE"]
@@ -20,6 +22,7 @@ ESP32_BLE_Presense = ESP32_BLE_Presense_ns.class_(
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(ESP32_BLE_Presense),
     cv.Required(CONF_AREA): cv.string,
+    cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
 }).extend(cv.COMPONENT_SCHEMA)
 
 async def to_code(config):
@@ -31,3 +34,7 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     cg.add(var.set_area(config[CONF_AREA]))
+
+    if CONF_TIME_ID in config:
+        time_ = await cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time(time_))

--- a/components/esp32_ble_presense/esp32_ble_presense.cpp
+++ b/components/esp32_ble_presense/esp32_ble_presense.cpp
@@ -12,6 +12,14 @@
 #define bleScanInterval 0x80 // Used to determine antenna sharing between Bluetooth and WiFi. Do not modify unless you are confident you know what you're doing
 #define bleScanWindow 0x40 // Used to determine antenna sharing between Bluetooth and WiFi. Do not modify unless you are confident you know what you're doing
 
+// Undo the default loose definitions in our file only
+#pragma GCC diagnostic error "-Wdeprecated-declarations"
+#pragma GCC diagnostic error "-Wsign-compare"
+#pragma GCC diagnostic error "-Wunused-but-set-variable"
+#pragma GCC diagnostic error "-Wunused-function"
+#pragma GCC diagnostic error "-Wunused-parameter"
+#pragma GCC diagnostic error "-Wunused-variable"
+
 using namespace esphome;
 
 namespace ESP32_BLE_Presense {

--- a/components/esp32_ble_presense/esp32_ble_presense.cpp
+++ b/components/esp32_ble_presense/esp32_ble_presense.cpp
@@ -88,7 +88,7 @@ void ESP32_BLE_Presense::reportDevice(const std::string& macAddress,
     std::string mac_address = capitalizeString(macAddress);
     unsigned long time = getTime();
     if (std::find(macs.begin(), macs.end(), mac_address) != macs.end()) {
-        ESP_LOGD("format_ble", ("Sending for " + mac_address).c_str());
+        ESP_LOGD("format_ble", "Sending for %s", mac_address.c_str());
         publish_json("format_ble_tracker/" + mac_address + "/" + name, [=](JsonObject root) {
             root["rssi"] = rssi;
             root["timestamp"] = time;
@@ -102,7 +102,7 @@ void ESP32_BLE_Presense::reportDevice(const std::string& macAddress,
         std::string uuid_str = capitalizeString(NimBLEUUID(reinterpret_cast<const uint8_t*>(&manufacturerData[UUID_INDEX]),
                                                            UUID_LEN, true).toString());
         if (std::find(uuids.begin(), uuids.end(), uuid_str) != uuids.end()) {
-            ESP_LOGD("format_ble", ("Sending for " + uuid_str).c_str());
+            ESP_LOGD("format_ble", "Sending for %s", uuid_str.c_str());
             publish_json("format_ble_tracker/" + uuid_str + "/" + name, [=](JsonObject root) {
                 root["rssi"] = rssi;
                 root["timestamp"] = time;
@@ -118,22 +118,22 @@ void ESP32_BLE_Presense::on_alive_message(const std::string &topic, const std::s
     if (payload == "True") {
         if (uid.rfind(":") != std::string::npos) {
             if (std::find(macs.begin(), macs.end(), uid) == macs.end()) {
-                ESP_LOGD("format_ble", ("Adding MAC  " + uid).c_str());
+                ESP_LOGD("format_ble", "Adding MAC  %s", uid.c_str());
                 macs.push_back(uid);
             } else {
-                ESP_LOGD("format_ble", ("Skipping duplicated MAC  " + uid).c_str());
+                ESP_LOGD("format_ble", "Skipping duplicated MAC  %s", uid.c_str());
             }
         } else if (uid.rfind("-") != std::string::npos) {
             if (std::find(uuids.begin(), uuids.end(), uid) == uuids.end()) {
-                ESP_LOGD("format_ble", ("Adding UUID " + uid).c_str());
+                ESP_LOGD("format_ble", "Adding UUID %s", uid.c_str());
                 uuids.push_back(uid);
             } else {
-                ESP_LOGD("format_ble", ("Skipping duplicated UUID  " + uid).c_str());
+                ESP_LOGD("format_ble", "Skipping duplicated UUID  %s", + uid.c_str());
             }
         }
         return;
     } else {
-        ESP_LOGD("format_ble", ("Removing " + uid).c_str());
+        ESP_LOGD("format_ble", "Removing %s", uid.c_str());
         macs.erase(std::remove(macs.begin(), macs.end(), uid), macs.end());
         uuids.erase(std::remove(uuids.begin(), uuids.end(), uid), uuids.end());
     }

--- a/components/esp32_ble_presense/esp32_ble_presense.cpp
+++ b/components/esp32_ble_presense/esp32_ble_presense.cpp
@@ -95,11 +95,12 @@ void ESP32_BLE_Presense::reportDevice(const std::string& macAddress,
         }, 1, true);
         return;
     }
-    std::string strManufacturerData = manufacturerData;
-    if (strManufacturerData != "") {
-        uint8_t cManufacturerData[100];
-        strManufacturerData.copy((char*)cManufacturerData, strManufacturerData.length(), 0);
-        std::string uuid_str = capitalizeString(NimBLEUUID(cManufacturerData+4, 16, true).toString().c_str());
+
+    static const size_t UUID_INDEX = 4;
+    static const size_t UUID_LEN = 16;
+    if (manufacturerData.length() > UUID_INDEX + UUID_LEN) {
+        std::string uuid_str = capitalizeString(NimBLEUUID(reinterpret_cast<const uint8_t*>(&manufacturerData[UUID_INDEX]),
+                                                           UUID_LEN, true).toString());
         if (std::find(uuids.begin(), uuids.end(), uuid_str) != uuids.end()) {
             ESP_LOGD("format_ble", ("Sending for " + uuid_str).c_str());
             publish_json("format_ble_tracker/" + uuid_str + "/" + name, [=](JsonObject root) {

--- a/components/esp32_ble_presense/esp32_ble_presense.cpp
+++ b/components/esp32_ble_presense/esp32_ble_presense.cpp
@@ -88,7 +88,7 @@ void ESP32_BLE_Presense::reportDevice(const std::string& macAddress,
     std::string mac_address = capitalizeString(macAddress);
     unsigned long time = getTime();
     if (std::find(macs.begin(), macs.end(), mac_address) != macs.end()) {
-        ESP_LOGD("format_ble", "Sending for %s", mac_address.c_str());
+        ESP_LOGD("format_ble", "Sending for '%s': %ddBm", mac_address.c_str(), rssi);
         publish_json("format_ble_tracker/" + mac_address + "/" + name, [=](JsonObject root) {
             root["rssi"] = rssi;
             root["timestamp"] = time;
@@ -102,7 +102,7 @@ void ESP32_BLE_Presense::reportDevice(const std::string& macAddress,
         std::string uuid_str = capitalizeString(NimBLEUUID(reinterpret_cast<const uint8_t*>(&manufacturerData[UUID_INDEX]),
                                                            UUID_LEN, true).toString());
         if (std::find(uuids.begin(), uuids.end(), uuid_str) != uuids.end()) {
-            ESP_LOGD("format_ble", "Sending for %s", uuid_str.c_str());
+            ESP_LOGD("format_ble", "Sending for '%s': %ddBm", uuid_str.c_str(), rssi);
             publish_json("format_ble_tracker/" + uuid_str + "/" + name, [=](JsonObject root) {
                 root["rssi"] = rssi;
                 root["timestamp"] = time;

--- a/components/esp32_ble_presense/esp32_ble_presense.cpp
+++ b/components/esp32_ble_presense/esp32_ble_presense.cpp
@@ -35,11 +35,13 @@ public:
     }
 };
 
-// Copies unneccessarily
-static std::string capitalizeString(std::string s) {
-    std::transform(s.begin(), s.end(), s.begin(),
+static std::string capitalizeString(const std::string& s) {
+    std::string ret;
+    ret.reserve(s.size());
+
+    std::transform(s.begin(), s.end(), std::back_inserter(ret),
                    [](unsigned char c){ return std::toupper(c); });
-    return s;
+    return ret;
 }
 
 static unsigned long getTime() {

--- a/components/esp32_ble_presense/esp32_ble_presense.h
+++ b/components/esp32_ble_presense/esp32_ble_presense.h
@@ -6,6 +6,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/mqtt/custom_mqtt_device.h"
+#include "esphome/components/time/real_time_clock.h"
 
 namespace ESP32_BLE_Presense {
 
@@ -15,6 +16,8 @@ class ESP32_BLE_Presense : public esphome::PollingComponent,
 
     std::vector<std::string> macs;
     std::vector<std::string> uuids;
+
+    esphome::time::RealTimeClock* rtc = 0;
 
 public:
 
@@ -26,6 +29,10 @@ public:
 
     void set_area(std::string area) {
         name = area;
+    }
+
+    void set_time(esphome::time::RealTimeClock* rtc) {
+        this->rtc = rtc;
     }
 
     ESP32_BLE_Presense(const ESP32_BLE_Presense&) = delete;

--- a/test/basic.yml
+++ b/test/basic.yml
@@ -50,3 +50,4 @@ mqtt:
 
 esp32_ble_presense:
   area: "Living Room"
+  time_id: homeassistant_time


### PR DESCRIPTION
The major change in here is to bind a time component to the sensor.  The point there being to ensure and document the link.

This is optional and will otherwise fall back to the default code.  The fallback could be removed so that the user is required to provide a time link - ie it would fail if no time handler is provided.

```yaml
time:
  - platform: homeassistant
    id: homeassistant_time

esp32_ble_presense:
  area: "Living Room"
  time_id: homeassistant_time
```

The minor changes are to remove some unnecessary copying and heap/string operations - namely:

1. `captializeString()` did a copy (and allocate) in and out - now it should copy once and move out.
2. `strManufacturerData` handling did a superfluous copy from the input parameter and then did a copy into a `uint8_t` buffer.  There was a potential (though unlikely) buffer overrun bug in that copy (`std::copy()` needs the destination length, not the source length) - but the actual `std::copy` itself wasn't necessary at all.
3. `ESP_LOGD("format_ble", ("Adding MAC  " + uid).c_str());` this allocates a new string on the heap and copies the fixed portion in, then copies the `uid` portion in, then deletes everything.   This version `ESP_LOGD("format_ble", "Adding MAC  %s", uid.c_str());` doesn't do any copies, it just prints it piece by piece (look up `printf` if you're not familiar - or python `%` formatting)
4. re-enable some useful warnings that esphome/platformio seems to suppress

Apologies - none of these changes are critical - but I review (and write) C++ code for a living ;-)